### PR TITLE
fixes a bug saving forms after adding, then removing a row.

### DIFF
--- a/merged_inlines/templates/admin/change_form_merged_inlines.html
+++ b/merged_inlines/templates/admin/change_form_merged_inlines.html
@@ -77,7 +77,7 @@
 <script type="text/javascript">
 {% for inline_admin_formset in inline_admin_formsets %}
     (function($) {
-      $("#all-inlines-group .tabular.inline-related tbody tr").mergedTabularFormset({
+      $("#all-inlines-group .tabular.inline-related tbody tr[id^='{{ inline_admin_formset.formset.prefix }}']").mergedTabularFormset({
         prefix: "{{ inline_admin_formset.formset.prefix }}",
         adminStaticPrefix: '{% static "admin/" %}',
         addText: "{% blocktrans with inline_admin_formset.opts.verbose_name|title as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}",


### PR DESCRIPTION
Adding a merged row, then removing it causes an error on save. This is because the indexes are incorrectly calculated after removing a row. That was caused by classes being applied to the wrong row types by the too broad jquery selector that I have altered in this PR.
